### PR TITLE
Fix name photo disappear after deleted

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     def versionMajor = 4
     def versionMinor = 3
-    def versionPatch = 6
+    def versionPatch = 7
 
     defaultConfig {
         applicationId "com.randomappsinc.studentpicker"

--- a/app/src/main/java/com/randomappsinc/studentpicker/photo/PictureUtils.java
+++ b/app/src/main/java/com/randomappsinc/studentpicker/photo/PictureUtils.java
@@ -79,7 +79,7 @@ class PictureUtils {
                 }
                 Uri targetUri = FileProvider.getUriForFile(context, Constants.FILE_PROVIDER_AUTHORITY, photoFile);
                 PictureUtils.copyFromUriIntoFile(contentResolver, takenPhotoUri, targetUri);
-                return takenPhotoUri;
+                return targetUri;
         }
 
         // If rotation was necessary, write rotated bitmap into a new file and return the URI for that file


### PR DESCRIPTION
It was a small fix. 

The only bug right now if we consider it as a bug is we are having two copies of the image that we take through the camera using the app.